### PR TITLE
refactor: Rename cacheTime to gcTime in cache configuration for consi…

### DIFF
--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -13,7 +13,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           queries: {
             // Using centralized cache configuration
             staleTime: DEFAULT_CACHE.staleTime,
-            cacheTime: DEFAULT_CACHE.gcTime,
+            gcTime: DEFAULT_CACHE.gcTime,
             retry: (failureCount, error) => {
               // Don't retry on 4xx errors except for 408, 429
               if (error && typeof error === "object" && "status" in error) {

--- a/lib/cache-config.ts
+++ b/lib/cache-config.ts
@@ -11,43 +11,43 @@ const DAY = HOUR * 24;
 // Common cache configurations
 export const DEFAULT_CACHE = {
   staleTime: 5 * MINUTE, // 5 minutes
-  cacheTime: 10 * MINUTE, // 10 minutes
+  gcTime: 10 * MINUTE, // 10 minutes (was cacheTime in v4)
 } as const;
 
 // Media details change less frequently than user data
 export const MEDIA_DETAILS_CACHE = {
   staleTime: 10 * MINUTE, // 10 minutes
-  cacheTime: 20 * MINUTE, // 20 minutes
+  gcTime: 20 * MINUTE, // 20 minutes (was cacheTime in v4)
 } as const;
 
 // User data should be fresher
 export const USER_DATA_CACHE = {
   staleTime: 1 * MINUTE, // 1 minute
-  cacheTime: 5 * MINUTE, // 5 minutes
+  gcTime: 5 * MINUTE, // 5 minutes (was cacheTime in v4)
 } as const;
 
 // Watch later data
 export const WATCH_LATER_CACHE = {
   staleTime: 5 * MINUTE, // 5 minutes
-  cacheTime: 10 * MINUTE, // 10 minutes
+  gcTime: 10 * MINUTE, // 10 minutes (was cacheTime in v4)
 } as const;
 
 // TMDB-specific cache configurations
 export const TMDB_CACHE = {
   SHORT: {
     staleTime: 5 * MINUTE, // 5 minutes
-    cacheTime: 10 * MINUTE, // 10 minutes
+    gcTime: 10 * MINUTE, // 10 minutes (was cacheTime in v4)
   },
   MEDIUM: {
     staleTime: 15 * MINUTE, // 15 minutes
-    cacheTime: 30 * MINUTE, // 30 minutes
+    gcTime: 30 * MINUTE, // 30 minutes (was cacheTime in v4)
   },
   LONG: {
     staleTime: 30 * MINUTE, // 30 minutes
-    cacheTime: 1 * HOUR, // 1 hour
+    gcTime: 1 * HOUR, // 1 hour (was cacheTime in v4)
   },
   VERY_LONG: {
     staleTime: 24 * HOUR, // 24 hours
-    cacheTime: 7 * DAY, // 7 days
+    gcTime: 7 * DAY, // 7 days (was cacheTime in v4)
   },
 } as const;


### PR DESCRIPTION
This pull request updates cache configuration terminology across the codebase to align with the latest conventions. Specifically, it replaces `cacheTime` with `gcTime` to improve clarity and consistency with version 4 changes.

### Cache configuration updates:

* [`components/providers/Providers.tsx`](diffhunk://#diff-db8e86b53b459749160035bd068aca46626e258cf6015c46c40e7a1c24ea3329L16-R16): Updated the `queries` configuration to use `gcTime` instead of `cacheTime` for centralized cache management.
* [`lib/cache-config.ts`](diffhunk://#diff-33b4f421fba1d28498827cb0666a31e449c022aa21077e1fbc28bece9d4afe4aL14-R51): Replaced all instances of `cacheTime` with `gcTime` across multiple cache configurations (`DEFAULT_CACHE`, `MEDIA_DETAILS_CACHE`, `USER_DATA_CACHE`, `WATCH_LATER_CACHE`, and `TMDB_CACHE`) for better alignment with the updated terminology. Each change includes a comment indicating the previous naming convention for context.…stency